### PR TITLE
Prevent fzf from opening files inside NERDTree's split

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -440,7 +440,7 @@ endif
 
 cnoremap <C-P> <C-R>=expand("%:p:h") . "/" <CR>
 nnoremap <silent> <leader>b :Buffers<CR>
-nnoremap <silent> <leader>e :FZF -m<CR>
+nnoremap <silent> <expr> <leader>e (expand('%') =~ 'NERD_tree' ? "\<c-w>\<c-w>" : '').":FZF -m<CR>"
 
 " make YCM compatible with UltiSnips (using supertab)
 let g:ycm_key_list_select_completion = ['<C-n>', '<Down>']


### PR DESCRIPTION
Added the fix suggested [here](https://github.com/junegunn/fzf/issues/453#issuecomment-166648024).