### PR TITLE
Prevent fzf :Buffers mapping from opening files inside NERDTree

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -457,7 +457,7 @@ if executable('rg')
 endif
 
 cnoremap <C-P> <C-R>=expand("%:p:h") . "/" <CR>
-nnoremap <silent> <leader>b :Buffers<CR>
+nnoremap <silent> <expr> <leader>b (expand('%') =~ 'NERD_tree' ? "\<c-w>\<c-w>" : '').":Buffers<CR>"
 nnoremap <silent> <expr> <leader>e (expand('%') =~ 'NERD_tree' ? "\<c-w>\<c-w>" : '').":FZF -m<CR>"
 
 " make YCM compatible with UltiSnips (using supertab)


### PR DESCRIPTION
Fix another issue similar to #8 